### PR TITLE
Using local state variable to update style type for menu

### DIFF
--- a/src/components/menu-modal/MenuModal.component.jsx
+++ b/src/components/menu-modal/MenuModal.component.jsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import './menu-modal.styles.scss';
 
-const MenuModal = ({ modalIsOpen, closeModal }) => {
+const MenuModal = ({ modalIsOpen, closeModal}) => {
   const [open, setOpenBool] = useState(true);
-  useEffect(()=> {
-    if (!open) {
-      closeModal();
-      setOpenBool(true);
-    }
-  });
+  if (!open) {
+    closeModal();
+    setOpenBool(true);
+  }
   return (
     <div className={`menu-modal column ${modalIsOpen ? "open" : ""}`}>
       <button onClick={() => closeModal()} className="no-bg-btn">

--- a/src/components/menu-modal/MenuModal.component.jsx
+++ b/src/components/menu-modal/MenuModal.component.jsx
@@ -1,19 +1,26 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import './menu-modal.styles.scss';
 
 const MenuModal = ({ modalIsOpen, closeModal }) => {
+  const [open, setOpenBool] = useState(true);
+  useEffect(()=> {
+    if (!open) {
+      closeModal();
+      setOpenBool(true);
+    }
+  });
   return (
     <div className={`menu-modal column ${modalIsOpen ? "open" : ""}`}>
       <button onClick={() => closeModal()} className="no-bg-btn">
         <i className="close-icon"></i>
       </button>
-      <Link className="menu-modal-link" to="/">Home</Link>
-      <Link className="menu-modal-link" to="/for-parents">For Parents</Link>
-      <Link className="menu-modal-link" to="/for-teachers">For Teachers</Link>
-      <Link className="menu-modal-link" to="/about">About Us</Link>
-      <Link className="menu-modal-link" to="/contact">Contact Us</Link>
+      <Link onClick={() => setOpenBool(false)} className="menu-modal-link" to="/">Home</Link>
+      <Link onClick={() => setOpenBool(false)} className="menu-modal-link" to="/for-parents">For Parents</Link>
+      <Link onClick={() => setOpenBool(false)} className="menu-modal-link" to="/for-teachers">For Teachers</Link>
+      <Link onClick={() => setOpenBool(false)} className="menu-modal-link" to="/about">About Us</Link>
+      <Link onClick={() => setOpenBool(false)} className="menu-modal-link" to="/contact">Contact Us</Link>
     </div>
   )
 };


### PR DESCRIPTION
I've created a state variable for the menu icon that is altered when a link is clicked so that when clicked on the mobile version, the menu will close on a new screen being deployed. It is my understanding that closeModal() simply changes the style type, so I use that similarly to how it is used by the menu icon. Rather than using modalIsOpen (props) I use a local state variable. I've also submitted an additional pull request(https://github.com/schoolclosures/covid-19-school-closures/pull/6) that simply closes the menu by calling closeModal() every time a link is clicked. This does not use a local state variable, but does look cleaner. Not sure about how it effects re-rendering of the DOM. 