### PR TITLE
adding closeModal() to all links to fix mobile menu UI issue

### DIFF
--- a/src/components/menu-modal/MenuModal.component.jsx
+++ b/src/components/menu-modal/MenuModal.component.jsx
@@ -9,11 +9,11 @@ const MenuModal = ({ modalIsOpen, closeModal }) => {
       <button onClick={() => closeModal()} className="no-bg-btn">
         <i className="close-icon"></i>
       </button>
-      <Link className="menu-modal-link" to="/">Home</Link>
-      <Link className="menu-modal-link" to="/for-parents">For Parents</Link>
-      <Link className="menu-modal-link" to="/for-teachers">For Teachers</Link>
-      <Link className="menu-modal-link" to="/about">About Us</Link>
-      <Link className="menu-modal-link" to="/contact">Contact Us</Link>
+      <Link onClick={() => closeModal()} className="menu-modal-link" to="/">Home</Link>
+      <Link onClick={() => closeModal()} className="menu-modal-link" to="/for-parents">For Parents</Link>
+      <Link onClick={() => closeModal()} className="menu-modal-link" to="/for-teachers">For Teachers</Link>
+      <Link onClick={() => closeModal()} className="menu-modal-link" to="/about">About Us</Link>
+      <Link onClick={() => closeModal()} className="menu-modal-link" to="/contact">Contact Us</Link>
     </div>
   )
 };


### PR DESCRIPTION
Here, rather than using a local state variable, I simply add closeModal() every time a link is clicked. This reacts similarly to my other pull request (https://github.com/schoolclosures/covid-19-school-closures/pull/5) , however it does not use a local state variable to determine whether or not to call closeModal(). 